### PR TITLE
Fix for the issue #2

### DIFF
--- a/lib/vagrant-bindfs/middleware.rb
+++ b/lib/vagrant-bindfs/middleware.rb
@@ -79,6 +79,7 @@ module VagrantBindfs
       @env[:ui].info I18n.t("vagrant.guest.linux.bindfs.status.binding")
       binded_folders.each do |opts|
           
+        next unless opts.include?(:path) and opts.include?(:bindpath)
         path, bindpath, args = normalize_options opts
         
         @env[:vm].channel.sudo("mkdir -p #{bindpath}")


### PR DESCRIPTION
The normalize_options add always the arguments, even if there is no path or bindpath, so it's better to check it first.
