### PR TITLE
Handling version specific options of bindfs with system without sort -V 

### DIFF
--- a/lib/vagrant-bindfs/command.rb
+++ b/lib/vagrant-bindfs/command.rb
@@ -152,8 +152,9 @@ module VagrantPlugins
       end
 
       def bindfs_version_lower_than(version)
-        test_command = %{test "$(echo "%{v} $(sudo bindfs --version | cut -d" " -f2)" | tr " " "\n" | sort -V | tail -n 1)" == "%{v}"}
-        @machine.communicate.test(test_command % { v: version})
+        bindfs_version_command = %{sudo bindfs --version | cut -d" " -f2}
+        bindfs_version = @machine.communicate.execute(bindfs_version_command);
+        Gem::Version.new(bindfs_version) < Gem::Version.new(version)
       end
 
     end


### PR DESCRIPTION
Hi,

Some old system did not have -V option avalaible to sort command. This break the version comparaison and did not permit to pass the right parameters to bindfs older than 1.12. So this patch handle the version comparaison internaly without the use of test and sort command.
This patch permit to use vagrant-binds with Red Hat Enterprise Linux Server release 5.10 with bindfs 1.8.3 rpm, and this also work with CentOS release 6.6 and bindfs 1.12.3 rpm.