### PR TITLE
Handle missing user and/or group

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,10 @@ bind_folders = Proc.new do |machine|
   # This should fail
   machine.bindfs.bind_folder "/etc3", "/etc-nonexit"
 
+  # These should also fail
+  machine.bindfs.bind_folder "/etc",  "/etc-binded-with-nonexistent-user", user: "nonuser"
+  machine.bindfs.bind_folder "/etc",  "/etc-binded-with-nonexistent-group", group: "nongroup"
+
 end
 
 Vagrant.configure("2") do |config|

--- a/lib/vagrant-bindfs/bind.rb
+++ b/lib/vagrant-bindfs/bind.rb
@@ -40,6 +40,22 @@ module VagrantPlugins
               next
             end
 
+            unless @machine.communicate.test("getent passwd #{command.user.shellescape}")
+              @env[:ui].error I18n.t(
+                "vagrant.config.bindfs.errors.user_not_exist",
+                user: command.user
+              )
+              next
+            end
+
+            unless @machine.communicate.test("getent passwd #{command.group.shellescape}")
+              @env[:ui].error I18n.t(
+                "vagrant.config.bindfs.errors.group_not_exist",
+                group: command.group
+              )
+              next
+            end
+
             if @machine.communicate.test("mount | grep bindfs | grep #{command.destination}")
               @env[:ui].info I18n.t(
                 "vagrant.config.bindfs.already_mounted",

--- a/lib/vagrant-bindfs/bind.rb
+++ b/lib/vagrant-bindfs/bind.rb
@@ -48,7 +48,7 @@ module VagrantPlugins
               next
             end
 
-            unless @machine.communicate.test("getent passwd #{command.group.shellescape}")
+            unless @machine.communicate.test("getent group #{command.group.shellescape}")
               @env[:ui].error I18n.t(
                 "vagrant.config.bindfs.errors.group_not_exist",
                 group: command.group

--- a/lib/vagrant-bindfs/command.rb
+++ b/lib/vagrant-bindfs/command.rb
@@ -19,6 +19,14 @@ module VagrantPlugins
         [ "bindfs", arguments.join(" "), source, destination ].compact.join(" ")
       end
 
+      def user
+        @arguments.join(' ')[/--(?:force-)?user=([^\s]+)/, 1]
+      end
+
+      def group
+        @arguments.join(' ')[/--(?:force-)?group=([^\s]+)/, 1]
+      end
+
       protected
 
       def arguments_for(options)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -12,6 +12,8 @@ en:
           destination_path_relative: "Destination path is relative for bind whatever"
           source_path_relative: "Source path is relative for bind whatever"
           source_path_not_exist: "Cannot bind source path %{path} because it doesn't exist"
+          user_not_exist: "Cannot bind to user '%{user}' because they don't exist"
+          group_not_exist: "Cannot bind to group '%{group}' because it doesn't exist"
           cannot_enable_fuse: "The fuse kernel module seems to not be loadable on the virtual machine"
           binding_failed: |-
             The bind command `%{command}` failed to run!


### PR DESCRIPTION
Currently vagrant-bindfs will crash if a user or group that do not exist are specified. This proves to be a problem if that user or group won't be created until after the VM is provisioned (I reported this problem with Issue #31).

This pull request changes this behaviour so that an error message is shown (just like it does when the source directory doesn't exist) but it does not crash.

With this new behaviour in place the binfs will fail, but the provisioning continues - when combined with the [vagrant-reload](https://github.com/aidanns/vagrant-reload) gem I'm now able to have the VM automatically rebooted after the initial provision and upon that second boot bindfs successfully binds to the new user and group as intended.

The changes are fairly minimal and I have added test bindings to the Vagrantfile, I can also confirm that this works in my own project.

If it's possible to get a new version of the gem released when (if) this is merged I'd really appreciate it.