### PR TITLE
Improve README and not_installed message

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ See [bindfs man page](http://bindfs.org/docs/bindfs.1.html) for details.
 vagrant-bindfs detects installed version of bindfs, translate option names when needed and ignore an option if it is not supported.
 As we may have missed something, it will warn you when a binding command fail.
 
-On Debian, SUSE and CentOS (5-6) guest systems, vagrant-bindfs will try to install bindfs automatically if it is not installed.
+On Debian (this includes Ubuntu), SUSE and CentOS (5-6) guest systems, vagrant-bindfs will try to install bindfs automatically if it is not installed.
 On other system, you'll get warned.
 
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,7 +2,7 @@ en:
   vagrant:
     config:
       bindfs:
-        not_installed: "Bindfs seems to not be installed on the virtual machine"
+        not_installed: "Bindfs seems to not be installed on the virtual machine, installing now"
         not_loaded: "Fuse kernel module seems to be not loaded, trying to load it"
         already_mounted: "There's already a bindfs mount to destination %{dest}"
         status:


### PR DESCRIPTION
To debug a completely unrelated vagrant issue, we were a little confused what is happening on Ubuntu and if bindfs is installed if not present.

Surely a minor, but it might help nob people coming after us. :smiley: 