### PR TITLE
Make version detection not choke on blank space

### DIFF
--- a/lib/vagrant-bindfs/command.rb
+++ b/lib/vagrant-bindfs/command.rb
@@ -179,8 +179,10 @@ module VagrantPlugins
               %{sudo -i bindfs --version | cut -d" " -f2}
             ].each do |command|
               @machine.communicate.execute(command) do |type, version|
-                @env[:ui].info("#{command}: #{version.inspect}") if @machine.config.bindfs.debug
-                throw(:version, Gem::Version.new(version)) if Gem::Version.correct?(version)
+                if version.strip().length > 0 then
+                  @env[:ui].info("#{command}: #{version.inspect}") if @machine.config.bindfs.debug
+                  throw(:version, Gem::Version.new(version)) if Gem::Version.correct?(version)
+                end
               end
             end
             Gem::Version.new("0.0")


### PR DESCRIPTION
People might have stuff that emits junk in `/etc/profile` or similar
files and the code could get a blank string from this and then
apparently `Gem::Version.correct?("")` returns a true value:

    irb(main):103:0* puts "version correct" if Gem::Version.correct?(""); Gem::Version.correct?("")
    version correct
    => 0

so that makes the code fail with:

    ...vagrant-bindfs/command.rb:183:in `throw': uncaught throw :version (ArgumentError)

This fixes it so that blank strings are ignored.

Fixes: GH-42