### PR TITLE
Workaround for the latest bindfs domain problems

### DIFF
--- a/lib/vagrant-bindfs/version.rb
+++ b/lib/vagrant-bindfs/version.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
     VERSION         = "0.4.8"
     
     SOURCE_VERSION  = "1.13.1"
-    SOURCE_URL      = "http://bindfs.org/downloads/bindfs-#{SOURCE_VERSION}.tar.gz"
+    SOURCE_URL      = "http://bindfs.dnsalias.org/downloads/bindfs-#{SOURCE_VERSION}.tar.gz"
     
   end
 end


### PR DESCRIPTION
Because of some issues on a main [bindfs websie](bindfs.org) this change will temporary fix the problem, as it was [written](https://github.com/gael-ian/vagrant-bindfs/issues/46#issuecomment-230266364) on a #46 issue. 