### PR TITLE
Make it depend on the minimal 2.0.0 version, Fixes #55

### DIFF
--- a/vagrant-bindfs.gemspec
+++ b/vagrant-bindfs.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.files       = Dir["{lib,locales}/**/*"] + ["README.md", "Rakefile", "MIT-LICENSE"]
   s.test_files  = Dir["{test}/**/*"] + ["Vagrantfile"]
   
-  s.required_ruby_version     = "~> 2.0.0"
+  s.required_ruby_version     = ">= 2.0.0"
   s.required_rubygems_version = ">= 1.3.6"
   
 end


### PR DESCRIPTION
`~> 2.0.0` evaluates as `['>= 2.0.0', '< 2.0.0']` according to http://guides.rubygems.org/patterns/
We need it to depend on the MINIMAL 2.0 version