### PR TITLE
Fix uninitialized constant VagrantBindfs::Bindfs::OptionSet::Forwardable

### DIFF
--- a/lib/vagrant-bindfs/bindfs/option_set.rb
+++ b/lib/vagrant-bindfs/bindfs/option_set.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'forwardable'
+
 module VagrantBindfs
   module Bindfs
     class OptionSet


### PR DESCRIPTION
After upgrading Vagrant to v1.9.0 and reinstalling my plugins (vagrant-bindfs@v1.0.0) I started seeing the error below anytime I attempted to run a Vagrant command. Vagrant itself was installed using Homebrew. The fix I'm including here resolved the issue for me, though I'm not super familiar with Ruby conventions and where the `require` would fit best -- happy to tweak in that regard.

```sh
/Users/rpnzl/.vagrant.d/gems/2.2.5/gems/vagrant-bindfs-1.0.0/lib/vagrant-bindfs/bindfs/option_set.rb:12:in `<class:OptionSet>': uninitialized constant VagrantBindfs::Bindfs::OptionSet::Forwardable (NameError)
  from /Users/rpnzl/.vagrant.d/gems/2.2.5/gems/vagrant-bindfs-1.0.0/lib/vagrant-bindfs/bindfs/option_set.rb:4:in `<module:Bindfs>'
  from /Users/rpnzl/.vagrant.d/gems/2.2.5/gems/vagrant-bindfs-1.0.0/lib/vagrant-bindfs/bindfs/option_set.rb:3:in `<module:VagrantBindfs>'
  from /Users/rpnzl/.vagrant.d/gems/2.2.5/gems/vagrant-bindfs-1.0.0/lib/vagrant-bindfs/bindfs/option_set.rb:2:in `<top (required)>'
  from /Users/rpnzl/.vagrant.d/gems/2.2.5/gems/vagrant-bindfs-1.0.0/lib/vagrant-bindfs/vagrant/config.rb:22:in `initialize'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/lib/vagrant/config/v2/root.rb:30:in `new'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/lib/vagrant/config/v2/root.rb:30:in `method_missing'
  from /Users/rpnzl/Sites/ml-magento/Vagrantfile:16:in `block in <top (required)>'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/lib/vagrant/config/v2/loader.rb:37:in `call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/lib/vagrant/config/v2/loader.rb:37:in `load'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/lib/vagrant/config/loader.rb:113:in `block (2 levels) in load'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/lib/vagrant/config/loader.rb:107:in `each'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/lib/vagrant/config/loader.rb:107:in `block in load'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/lib/vagrant/config/loader.rb:104:in `each'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/lib/vagrant/config/loader.rb:104:in `load'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/lib/vagrant/vagrantfile.rb:28:in `initialize'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/lib/vagrant/environment.rb:746:in `new'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/lib/vagrant/environment.rb:746:in `vagrantfile'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/lib/vagrant/environment.rb:492:in `host'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/lib/vagrant/environment.rb:214:in `block in action_runner'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/lib/vagrant/action/runner.rb:33:in `call'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/lib/vagrant/action/runner.rb:33:in `run'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/lib/vagrant/environment.rb:479:in `hook'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/lib/vagrant/environment.rb:728:in `unload'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/bin/vagrant:126:in `ensure in <main>'
  from /opt/vagrant/embedded/gems/gems/vagrant-1.9.0/bin/vagrant:126:in `<main>'
```
