### PR TITLE
Fix when input is a symbol

### DIFF
--- a/lib/vagrant-bindfs/vagrant/capabilities/linux/system_checks.rb
+++ b/lib/vagrant-bindfs/vagrant/capabilities/linux/system_checks.rb
@@ -8,14 +8,14 @@ module VagrantBindfs
             def bindfs_exists_user(machine, user)
               (
                 user.nil? || \
-                machine.communicate.test("getent passwd #{user.shellescape}")
+                machine.communicate.test("getent passwd #{user.to_s.shellescape}")
               )
             end
 
             def bindfs_exists_group(machine, group)
               (
                 group.nil? || \
-                machine.communicate.test("getent group #{group.shellescape}")
+                machine.communicate.test("getent group #{group.to_s.shellescape}")
               )
             end
           end


### PR DESCRIPTION
After upgrading to Vagrant 1.9.0 and vagrant-bindfs 1.0.1, I get `/Users/pdesgarets/.vagrant.d/gems/2.2.5/gems/vagrant-bindfs-1.0.1/lib/vagrant-bindfs/vagrant/capabilities/linux/system_checks.rb:11:in `bindfs_exists_user': undefined method `shellescape' for :vagrant:Symbol (NoMethodError)` when I try to `vagrant up` a vm that is halted. 

This is a simple fix, casting the symbol to a string to use shellescape method.

I don't know if this fix should also be applied to other shellescape in vagrant-bindfs, "just in case".