### PR TITLE
Fix for finding bindfs fullt path w/ bash hashing

### DIFF
--- a/lib/vagrant-bindfs/vagrant/capabilities/all/bindfs.rb
+++ b/lib/vagrant-bindfs/vagrant/capabilities/all/bindfs.rb
@@ -6,7 +6,7 @@ module VagrantBindfs
         module Bindfs
           class << self
             def bindfs_bindfs_full_path(machine)
-              machine.communicate.execute('type -p bindfs | cut -d" " -f3') do |_, output|
+              machine.communicate.execute('type -p bindfs') do |_, output|
                 path = output.strip
                 return path unless path.empty?
               end

--- a/lib/vagrant-bindfs/vagrant/capabilities/all/bindfs.rb
+++ b/lib/vagrant-bindfs/vagrant/capabilities/all/bindfs.rb
@@ -6,7 +6,7 @@ module VagrantBindfs
         module Bindfs
           class << self
             def bindfs_bindfs_full_path(machine)
-              machine.communicate.execute('type bindfs | cut -d" " -f3') do |_, output|
+              machine.communicate.execute('type -p bindfs | cut -d" " -f3') do |_, output|
                 path = output.strip
                 return path unless path.empty?
               end


### PR DESCRIPTION
The 3rd column output is "hashed" when the bindfs in path is already hashed. (See man type).

eg

>$ type bindfs | cut -d" " -f3
> hashed

My fix

>$ type -p bindfs | cut -d" " -f3
> /usr/bin/bindfs