### PR TITLE
Removed reserved destination path validation

### DIFF
--- a/lib/vagrant-bindfs/bindfs/validators/config.rb
+++ b/lib/vagrant-bindfs/bindfs/validators/config.rb
@@ -35,7 +35,6 @@ module VagrantBindfs
         def validate_destination!
           @errors << I18n.t('vagrant-bindfs.validations.destination_path_required')                     if destination.empty?
           @errors << I18n.t('vagrant-bindfs.validations.path_must_be_absolute', path: destination)      if relative_path?(destination)
-          @errors << I18n.t('vagrant-bindfs.validations.destination_path_reserved', path: destination)  if reserved_path?(destination)
         end
 
         def validate_options!
@@ -48,10 +47,6 @@ module VagrantBindfs
 
         def relative_path?(path)
           Pathname.new(path).relative?
-        end
-
-        def reserved_path?(path)
-          !Pathname.new(path).to_path.match(%r{^\/vagrant\/}).nil?
         end
       end
     end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -28,7 +28,6 @@ en:
       source_path_does_not_exist: "Source path '%{path}' doesn't exist"
 
       destination_path_required: "A destination path is required as argument to bind_folder"
-      destination_path_reserved: "Destination path '%{path}' is part of a reserved subtree for Vagrant use"
       destination_already_mounted: "Destination path '%{dest}' is already a bindfs mount"
 
       path_must_be_absolute: "Path '%{path}' is relative but an absolute path is attended"


### PR DESCRIPTION
Hi,

I was not able to find a reason why it is not possible to set destination path inside `/vagrant/` path. Such setup is completely valid and works. I don't see a reason to block such behaviour. I suggest to remove the check.