### PR TITLE
Rollback targeted Ruby version to Ruby 3.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 3.3
+  TargetRubyVersion: 3.0
   NewCops: enable
 
 Naming/FileName:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## Version 1.3.1 (2024-08-24)
+
 ## Fixed
 
 * Rollback uses of Ruby 3.1+ syntaxic sugar for compatibility with Ruby 3.0 (#111)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## Fixed
+
+* Rollback uses of Ruby 3.1+ syntaxic sugar for compatibility with Ruby 3.0 (#111)
+
 ## Version 1.3.0 (2024-08-23)
 
 ### Breaking changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GIT
 PATH
   remote: .
   specs:
-    vagrant-bindfs (1.3.0)
+    vagrant-bindfs (1.3.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/vagrant-bindfs/vagrant/actions/mounter.rb
+++ b/lib/vagrant-bindfs/vagrant/actions/mounter.rb
@@ -27,7 +27,7 @@ module VagrantBindfs
         protected
 
         def bind_folders!
-          info I18n.t('vagrant-bindfs.actions.mounter.start', hook:)
+          info I18n.t('vagrant-bindfs.actions.mounter.start', hook: hook)
           bound_folders(hook).each_value do |folder|
             bind_folder!(folder)
           end

--- a/lib/vagrant-bindfs/version.rb
+++ b/lib/vagrant-bindfs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module VagrantBindfs
-  VERSION = '1.3.0'
+  VERSION = '1.3.1'
 end


### PR DESCRIPTION
Should fix #110 for older versions of Vagrant.